### PR TITLE
Fix: Producer - flush_records not working

### DIFF
--- a/lib/kinesis/producer.rb
+++ b/lib/kinesis/producer.rb
@@ -66,11 +66,14 @@ module Kinesis
     end
 
     def flush_records
+      @timer_start = Time.now
+
       return if @record_queue.empty?
 
       # Log: Flushing #{@record_queue.size} records
+      records = []
 
-      records = @record_queue.size.times { @record_queue.pop }
+      @record_queue.size.times { records << @record_queue.pop }
 
       @kinesis_client.put_records(
         records: records,
@@ -78,10 +81,8 @@ module Kinesis
       )
 
       @next_record_queue.size.times { @record_queue << @next_record_queue.pop }
-
       @record_count = 0
       @record_size = 0
-      @timer_start = Time.now
     end
   end
 

--- a/lib/kinesis/producer.rb
+++ b/lib/kinesis/producer.rb
@@ -78,6 +78,10 @@ module Kinesis
       )
 
       @next_record_queue.size.times { @record_queue << @next_record_queue.pop }
+
+      @record_count = 0
+      @record_size = 0
+      @timer_start = Time.now
     end
   end
 


### PR DESCRIPTION
Overlooked:
1. producer resetting the counter and timer when done flushing records to Kinesis
2. producer wasn't working in the first place, using `.times { pop }` incorrectly and popped out `.times` counter instead of the record