### PR TITLE
Fix: CPU utilization at 100%

### DIFF
--- a/lib/kinesis/consumer.rb
+++ b/lib/kinesis/consumer.rb
@@ -8,6 +8,7 @@ module Kinesis
   # Kinesis::Consumer
   class Consumer
     LOCK_DURATION = 30 # seconds
+    READ_INTERVAL = 0.05 # seconds
 
     def initialize(
       stream_name:,
@@ -39,6 +40,8 @@ module Kinesis
           break if (Time.now - setup_time) > (@lock_duration - 1)
 
           wait_for_records { |item| yield item }
+
+          sleep READ_INTERVAL # without sleep, CPU utilization shoots up 100%
         end
       end
     rescue SignalException => e


### PR DESCRIPTION
CPU shoots up at 100% for Ruby with infinite loops (smh)

Python too, at 40-50% when I tested

I'm taking a leaf off of offspring (the multiprocessing magic behind kinesis-python)https://github.com/borgstrom/offspring/blob/master/src/offspring/process.py#L126
that lets the infinite loop sleep at least 0.05 second intervals

When I tested this, CPU usage goes down to 1-2%