### PR TITLE
Fix: consumerId comparison is incorrect

### DIFF
--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -80,7 +80,7 @@ module Kinesis
       if resp[:item]
         shard = resp[:item].dig('shards', shard_id)
 
-        if shard && shard != @consumer_id && Time.parse(shard['expiresIn']) > Time.now
+        if shard && shard['consumerId'] != @consumer_id && Time.parse(shard['expiresIn']) > Time.now
           # Log: Not starting reader for shard; Locked by different {consumerId} until {expiresIn}
           return false
         end


### PR DESCRIPTION
Since it never properly compares consumerId, it just blindly shuts down and creates a new shard reader each time `setup_shards` is called