### PR TITLE
fix: Multi-shard Consumers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kinesis (0.0.3)
+    kinesis (0.0.4)
       aws-sdk-dynamodb (~> 1)
       aws-sdk-kinesis (~> 1)
       concurrent-ruby (~> 1.0)
@@ -10,7 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.396.0)
+    aws-partitions (1.397.0)
     aws-sdk-core (3.109.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -45,7 +45,8 @@ module Kinesis
           'streamName': @stream_name
         },
         expression_attribute_names: {
-          '#shard_id': shard_id
+          '#shard_id': shard_id,
+          '#shards': 'shards'
         },
         expression_attribute_values: {
           ':consumer_group': @consumer_group,
@@ -56,10 +57,10 @@ module Kinesis
           'consumerGroup = :consumer_group AND ' \
           'streamName = :stream_name AND ' \
           '(' \
-          '  attribute_not_exists(shards.#shard_id.checkpoint) OR ' \
-          '  shards.#shard_id.checkpoint < :sequence_number ' \
+          '  attribute_not_exists(#shards.#shard_id.checkpoint) OR ' \
+          '  #shards.#shard_id.checkpoint < :sequence_number ' \
           ')',
-        update_expression: 'SET shards.#shard_id.checkpoint = :sequence_number'
+        update_expression: 'SET #shards.#shard_id.checkpoint = :sequence_number'
       )
     end
 
@@ -130,18 +131,19 @@ module Kinesis
         table_name: @dynamodb_table_name,
         key: key,
         expression_attribute_names: {
-          '#shard_id': shard_id
+          '#shard_id': shard_id,
+          '#shards': 'shards'
         },
         expression_attribute_values: {
           ':consumer_id': @consumer_id,
           ':expires': expiry
         },
         condition_expression:
-          'attribute_not_exists(shards.#shard_id)',
+          'attribute_not_exists(#shards.#shard_id)',
         update_expression:
           'SET ' \
-          'shards.#shard_id.consumerId = :consumer_id, ' \
-          'shards.#shard_id.expiresIn = :expires'
+          '#shards.#shard_id.consumerId = :consumer_id, ' \
+          '#shards.#shard_id.expiresIn = :expires'
       )
       @shards[shard_id] = {
         'consumerId': @consumer_id,
@@ -159,7 +161,8 @@ module Kinesis
         table_name: @dynamodb_table_name,
         key: key,
         expression_attribute_names: {
-          '#shard_id': shard_id
+          '#shard_id': shard_id,
+          '#shards': 'shards'
         },
         expression_attribute_values: {
           ':new_consumer_id': @consumer_id,
@@ -168,12 +171,12 @@ module Kinesis
           ':current_expires': current_expiry
         },
         condition_expression:
-          'shards.#shard_id.consumerId = :current_consumer_id AND ' \
-          'shards.#shard_id.expiresIn = :current_expires',
+          '#shards.#shard_id.consumerId = :current_consumer_id AND ' \
+          '#shards.#shard_id.expiresIn = :current_expires',
         update_expression:
           'SET ' \
-          'shards.#shard_id.consumerId = :new_consumer_id, ' \
-          'shards.#shard_id.expiresIn = :new_expires'
+          '#shards.#shard_id.consumerId = :new_consumer_id, ' \
+          '#shards.#shard_id.expiresIn = :new_expires'
       )
       @shards[shard_id] = {
         'consumerId': @consumer_id,

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -45,7 +45,6 @@ module Kinesis
           'streamName': @stream_name
         },
         expression_attribute_names: {
-          '#shards': 'shards',
           '#shard_id': shard_id
         },
         expression_attribute_values: {
@@ -57,10 +56,10 @@ module Kinesis
           'consumerGroup = :consumer_group AND ' \
           'streamName = :stream_name AND ' \
           '(' \
-          '  attribute_not_exists(#shards.#shard_id.checkpoint) OR ' \
-          '  #shards.#shard_id.checkpoint < :sequence_number ' \
+          '  attribute_not_exists(shards.#shard_id.checkpoint) OR ' \
+          '  shards.#shard_id.checkpoint < :sequence_number ' \
           ')',
-        update_expression: 'SET #shards.#shard_id.checkpoint = :sequence_number'
+        update_expression: 'SET shards.#shard_id.checkpoint = :sequence_number'
       )
     end
 
@@ -138,7 +137,7 @@ module Kinesis
           ':expires': expiry
         },
         condition_expression:
-          'attribute_not_exists(#shards.#shard_id)',
+          'attribute_not_exists(shards.#shard_id)',
         update_expression:
           'SET ' \
           'shards.#shard_id.consumerId = :consumer_id, ' \

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -131,21 +131,18 @@ module Kinesis
         table_name: @dynamodb_table_name,
         key: key,
         expression_attribute_names: {
-          '#consumer_group': 'consumerGroup',
-          '#shard_id': shard_id,
-          '#shards': 'shards',
-          '#stream_name': 'streamName'
+          '#shard_id': shard_id
         },
         expression_attribute_values: {
           ':consumer_id': @consumer_id,
-          ':expires': expiry,
+          ':expires': expiry
         },
         condition_expression:
           'attribute_not_exists(#shards.#shard_id)',
         update_expression:
           'SET ' \
-          '#shards.#shard_id.consumerId = :consumer_id, ' \
-          '#shards.#shard_id.expiresIn = :expires'
+          'shards.#shard_id.consumerId = :consumer_id, ' \
+          'shards.#shard_id.expiresIn = :expires'
       )
       @shards[shard_id] = {
         'consumerId': @consumer_id,
@@ -163,26 +160,21 @@ module Kinesis
         table_name: @dynamodb_table_name,
         key: key,
         expression_attribute_names: {
-          '#consumer_group': 'consumerGroup',
-          '#shard_id': shard_id,
-          '#shards': 'shards',
-          '#stream_name': 'streamName'
+          '#shard_id': shard_id
         },
         expression_attribute_values: {
           ':new_consumer_id': @consumer_id,
           ':new_expires': new_expiry,
           ':current_consumer_id': current_consumer_id,
-          ':current_expires': current_expiry,
-          ':consumer_group': @consumer_group,
-          ':stream_name': @stream_name
+          ':current_expires': current_expiry
         },
         condition_expression:
-          '#shards.#shard_id.consumerId = :current_consumer_id AND ' \
-          '#shards.#shard_id.expiresIn = :current_expires',
+          'shards.#shard_id.consumerId = :current_consumer_id AND ' \
+          'shards.#shard_id.expiresIn = :current_expires',
         update_expression:
           'SET ' \
-          '#shards.#shard_id.consumerId = :new_consumer_id, ' \
-          '#shards.#shard_id.expiresIn = :new_expires'
+          'shards.#shard_id.consumerId = :new_consumer_id, ' \
+          'shards.#shard_id.expiresIn = :new_expires'
       )
       @shards[shard_id] = {
         'consumerId': @consumer_id,

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -99,9 +99,12 @@ module Kinesis
 
       if @shards[shard_id].nil?
         create_new_lock(expires_in, shard_id)
+        @logger.info(message: "Created new lock for shard #{shard_id}")
       else # update the lock
         update_lock(expires_in, shard_id, key)
+      @logger.info(message: "Updated lock for shard #{shard_id}")
       end
+      @logger.info(message: "@shards hash", shards: @shards)
 
       true
     rescue StandardError => e

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -66,8 +66,6 @@ module Kinesis
 
     def lock_shard(shard_id, expires_in)
       return true unless plugged_in?
-      @logger.info(message: "@shards hash: #{@shards.to_json}")
-      @logger.info(message: "Locking shard #{shard_id}...")
 
       key = {
         'consumerGroup': @consumer_group,
@@ -101,13 +99,9 @@ module Kinesis
 
       if @shards[shard_id].nil?
         create_new_lock(expires_in, shard_id, key)
-        @logger.info(message: "Created new lock for shard #{shard_id}")
       else # update the lock
         update_lock(expires_in, shard_id, key)
-        @logger.info(message: "Updated lock for shard #{shard_id}")
       end
-      @logger.info(message: "Locked shard #{shard_id}")
-      @logger.info(message: "@shards hash: #{@shards.to_json}")
 
       true
     rescue StandardError => e

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -45,8 +45,7 @@ module Kinesis
           'streamName': @stream_name
         },
         expression_attribute_names: {
-          '#shard_id': shard_id,
-          '#shards': 'shards'
+          '#shard_id': shard_id
         },
         expression_attribute_values: {
           ':consumer_group': @consumer_group,
@@ -57,10 +56,10 @@ module Kinesis
           'consumerGroup = :consumer_group AND ' \
           'streamName = :stream_name AND ' \
           '(' \
-          '  attribute_not_exists(#shards.#shard_id.checkpoint) OR ' \
-          '  #shards.#shard_id.checkpoint < :sequence_number ' \
+          '  attribute_not_exists(shards.#shard_id.checkpoint) OR ' \
+          '  shards.#shard_id.checkpoint < :sequence_number ' \
           ')',
-        update_expression: 'SET #shards.#shard_id.checkpoint = :sequence_number'
+        update_expression: 'SET shards.#shard_id.checkpoint = :sequence_number'
       )
     end
 
@@ -128,14 +127,13 @@ module Kinesis
         table_name: @dynamodb_table_name,
         key: key,
         expression_attribute_names: {
-          '#shard_id': shard_id,
-          '#shards': 'shards'
+          '#shard_id': shard_id
         },
         expression_attribute_values: {
           ':shard': shard
         },
-        condition_expression: 'attribute_not_exists(#shards.#shard_id)',
-        update_expression: 'SET #shards.#shard_id = :shard'
+        condition_expression: 'attribute_not_exists(shards.#shard_id)',
+        update_expression: 'SET shards.#shard_id = :shard'
       )
       @shards[shard_id] = shard
     end
@@ -150,8 +148,7 @@ module Kinesis
         table_name: @dynamodb_table_name,
         key: key,
         expression_attribute_names: {
-          '#shard_id': shard_id,
-          '#shards': 'shards'
+          '#shard_id': shard_id
         },
         expression_attribute_values: {
           ':new_consumer_id': @consumer_id,
@@ -160,12 +157,12 @@ module Kinesis
           ':current_expires': current_expiry
         },
         condition_expression:
-          '#shards.#shard_id.consumerId = :current_consumer_id AND ' \
-          '#shards.#shard_id.expiresIn = :current_expires',
+          'shards.#shard_id.consumerId = :current_consumer_id AND ' \
+          'shards.#shard_id.expiresIn = :current_expires',
         update_expression:
           'SET ' \
-          '#shards.#shard_id.consumerId = :new_consumer_id, ' \
-          '#shards.#shard_id.expiresIn = :new_expires'
+          'shards.#shard_id.consumerId = :new_consumer_id, ' \
+          'shards.#shard_id.expiresIn = :new_expires'
       )
       @shards[shard_id] = {
         'consumerId': @consumer_id,

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -66,6 +66,8 @@ module Kinesis
 
     def lock_shard(shard_id, expires_in)
       return true unless plugged_in?
+      @logger.info(message: "@shards hash: #{@shards.to_json}")
+      @logger.info(message: "Locking shard #{shard_id}...")
 
       key = {
         'consumerGroup': @consumer_group,
@@ -102,9 +104,10 @@ module Kinesis
         @logger.info(message: "Created new lock for shard #{shard_id}")
       else # update the lock
         update_lock(expires_in, shard_id, key)
-      @logger.info(message: "Updated lock for shard #{shard_id}")
+        @logger.info(message: "Updated lock for shard #{shard_id}")
       end
-      @logger.info(message: "@shards hash", shards: @shards)
+      @logger.info(message: "Locked shard #{shard_id}")
+      @logger.info(message: "@shards hash: #{@shards.to_json}")
 
       true
     rescue StandardError => e

--- a/lib/kinesis/version.rb
+++ b/lib/kinesis/version.rb
@@ -1,3 +1,3 @@
 module Kinesis
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/kinesis/consumer_spec.rb
+++ b/spec/kinesis/consumer_spec.rb
@@ -9,26 +9,17 @@ require 'aws-sdk-dynamodb'
 describe Kinesis::Consumer do
   let(:kinesis_client) do
     client = Aws::Kinesis::Client.new(stub_responses: true)
-    client.stub_responses(:describe_stream, {
-      stream_description: {
-        stream_name: 'dummy',
-        stream_arn: 'dummy',
-        stream_status: 'dummy',
-        has_more_shards: false,
-        retention_period_hours: 1,
-        stream_creation_timestamp: Time.now,
-        enhanced_monitoring: [],
-        shards: [{
-          hash_key_range: {
-            starting_hash_key: '123',
-            ending_hash_key: '123'
-          },
-          sequence_number_range: {
-            starting_sequence_number: '123'
-          },
-          shard_id: 'dummy_shard_id'
-        }]
-      }
+    client.stub_responses(:list_shards, {
+      shards: [{
+        hash_key_range: {
+          starting_hash_key: '123',
+          ending_hash_key: '123'
+        },
+        sequence_number_range: {
+          starting_sequence_number: '123'
+        },
+        shard_id: 'dummy_shard_id'
+      }]
     })
     client
   end


### PR DESCRIPTION
#### Context

Consumers would fail if there was more than 1 shard present for a stream. The current implementation also locks/polls all shards, regardless of whether the shards are active or not.

#### Changes

- Changed `Kinesis::Consumer#setup_shards` to only work on currently active shards
- Changed `Kinesis::State#create_new_lock` to use `update_item` instead of `put_item` to prevent overwriting existing locks
- Update the current `@shards` hash in `Kinesis::State` after locking a shard.
- Removed redundant expression attribute name for `#shards` in Dynamodb calls