### PR TITLE
fix: create new lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kinesis (0.0.4)
+    kinesis (0.0.5)
       aws-sdk-dynamodb (~> 1)
       aws-sdk-kinesis (~> 1)
       concurrent-ruby (~> 1.0)
@@ -10,13 +10,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.397.0)
+    aws-partitions (1.399.0)
     aws-sdk-core (3.109.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-dynamodb (1.57.0)
+    aws-sdk-dynamodb (1.58.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-kinesis (1.30.0)

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -140,6 +140,7 @@ module Kinesis
     rescue Aws::DynamoDB::Errors::ValidationException => e
       raise e unless retry_once_on_failure
 
+      # possible that `shards -> consumer_group` item doesn't exist yet
       @dynamodb_client.update_item(
         table_name: @dynamodb_table_name,
         key: key,

--- a/lib/kinesis/version.rb
+++ b/lib/kinesis/version.rb
@@ -1,3 +1,3 @@
 module Kinesis
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Was getting this error when trying to run it for a new state table (kinesis-state-dev-odina):

```
Aws::DynamoDB::Errors::ValidationException: The document path provided in the update expression is invalid for update
...
/usr/local/bundle/ruby/2.5.0/bundler/gems/kinesis-rb-e748cd4e039d/lib/kinesis/state.rb:126:in `create_new_lock'
...                                                                                                                                                                                                              
```