### PR TITLE
Add heartbeat to consumer info, default LATEST if heartbeat stale [TUNA-64]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kinesis (0.0.5)
+    kinesis (0.0.6)
       aws-sdk-dynamodb (~> 1)
       aws-sdk-kinesis (~> 1)
       concurrent-ruby (~> 1.0)
@@ -10,8 +10,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.399.0)
-    aws-sdk-core (3.109.3)
+    aws-partitions (1.404.0)
+    aws-sdk-core (3.110.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)

--- a/lib/kinesis/consumer.rb
+++ b/lib/kinesis/consumer.rb
@@ -19,6 +19,7 @@ module Kinesis
       logger: nil,
       reader_sleep_time: nil
     )
+      @dynamodb = dynamodb
       @error_queue = Queue.new
       @lock_duration = lock_duration
       @kinesis_client = kinesis[:client] || Aws::Kinesis::Client.new
@@ -35,9 +36,9 @@ module Kinesis
 
       @stream_info = @kinesis_client.describe_stream(stream_name: @stream_name)
       @state = State.new(
-        dynamodb: dynamodb,
+        dynamodb: @dynamodb,
         logger: @logger,
-        stream_name: stream_name,
+        stream_name: @stream_name,
         stream_retention_period_in_hours: @stream_info.dig(:stream_description, :retention_period_hours)
       )
 

--- a/lib/kinesis/consumer.rb
+++ b/lib/kinesis/consumer.rb
@@ -30,7 +30,7 @@ module Kinesis
       @state = nil
     end
 
-    def each
+    def each(&block)
       trap('INT') { raise SignalException.new('SIGTERM') }
 
       @stream_info = @kinesis_client.describe_stream(stream_name: @stream_name)
@@ -49,7 +49,7 @@ module Kinesis
           # @lock_duration - 1 because we want to refresh just before it expires
           break if (Time.now - setup_time) > (@lock_duration - 1)
 
-          wait_for_records { |item| yield item }
+          wait_for_records { |item| block.call(item) }
 
           sleep READ_INTERVAL # without sleep, CPU utilization shoots up 100%
         end

--- a/lib/kinesis/shard_reader.rb
+++ b/lib/kinesis/shard_reader.rb
@@ -58,7 +58,7 @@ module Kinesis
         sleep_time = [MAX_SLEEP_TIME, @retries * 2].min
         @retries += 1
 
-        @logger.warn(
+        @logger.info(
           {
             message: 'Retryable exception encountered when getting records',
             error: e,
@@ -66,7 +66,7 @@ module Kinesis
           }
         )
       else
-        @logger.warn(
+        @logger.info(
           {
             message: 'Error encountered when getting records',
             error: e,

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -82,6 +82,8 @@ module Kinesis
           'shards.#shard_id.checkpoint = :sequence_number, ' \
           'shards.#shard_id.heartbeat = :heartbeat'
       )
+
+      @shards[shard_id]['checkpoint'] = sequence_number
     end
 
     def lock_shard(shard_id, expires_in)

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -92,7 +92,7 @@ module Kinesis
       resp = @dynamodb_client.get_item(
         table_name: @dynamodb_table_name,
         consistent_read: true,
-        key: key
+        key: @key
       )
 
       if resp[:item]

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -10,7 +10,7 @@ module Kinesis
 
     # dynamodb[:consumer_group] - Preferrably the name of the application using the gem,
     #                             otherwise will just default to the root dir
-    def initialize(dynamodb: {}, stream_name:, stream_retention_period_in_hours: 24, logger:)
+    def initialize(dynamodb: {}, stream_name:, stream_retention_period_in_hours:, logger:)
       @consumer_group = dynamodb[:consumer_group] || File.basename(Dir.getwd)
       @consumer_id = Socket.gethostbyname(Socket.gethostname).first
       @dynamodb_client = dynamodb[:client]

--- a/lib/kinesis/state.rb
+++ b/lib/kinesis/state.rb
@@ -38,7 +38,7 @@ module Kinesis
       heartbeat_diff = Time.now.utc - Time.parse(heartbeat).utc
 
       if heartbeat_diff > (60 * 60 * @stream_retention_period_in_hours)
-        @logger.warn(
+        @logger.info(
           {
             message: 'Heartbeat is stale, defaulting to LATEST',
             sequence_number: last_sequence_number,
@@ -124,7 +124,7 @@ module Kinesis
     rescue StandardError => e
       raise e unless Kinesis::RETRYABLE_EXCEPTIONS.include?(e.class.name)
 
-      @logger.warn(
+      @logger.info(
         {
           message: 'Throttled while trying to read lock table in Dynamo'
         }

--- a/lib/kinesis/version.rb
+++ b/lib/kinesis/version.rb
@@ -1,3 +1,3 @@
 module Kinesis
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/kinesis/state_spec.rb
+++ b/spec/kinesis/state_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'spec_helper'
+require 'kinesis/state'
+require 'aws-sdk-kinesis'
+require 'aws-sdk-dynamodb'
+
+describe Kinesis::State do
+  let(:logger) { double(warn: nil) }
+  let(:state) { described_class.new(stream_name: 'test', logger: logger) }
+
+  describe '#get_iterator_args' do
+    context 'if shard does not exist' do
+      it 'should return LATEST' do
+        resp = state.get_iterator_args('non_existent_shard')
+
+        expect(resp).to eq({ shard_iterator_type: 'LATEST' })
+      end
+    end
+
+    context 'if shard exists' do
+      let(:shard_name) { 'test' }
+      let(:iterator_args) { state.get_iterator_args(shard_name) }
+
+      before do
+        state.shards[shard_name] = {
+          'checkpoint' => 'test123',
+          'consumerId' => shard_name,
+          'expiresIn' => (Time.now.utc + (60 * 60 * 24)).iso8601 # 24 hours from now
+        }
+      end
+
+      context 'and heartbeat is up-to-date' do
+        before do
+          state.shards[shard_name]['heartbeat'] = Time.now.utc.iso8601
+        end
+
+        it 'should return AFTER_SEQUENCE_NUMBER' do
+          expect(iterator_args).to include({ shard_iterator_type: 'AFTER_SEQUENCE_NUMBER' })
+        end
+      end
+
+      context 'and heartbeat is stale' do
+        before do
+          state.shards[shard_name]['heartbeat'] = (Time.now.utc - (60 * 60 * 25)).iso8601 # 25 hours ago
+        end
+
+        it 'should log a warning' do
+          expect(logger).to receive(:warn)
+          iterator_args
+        end
+
+        it 'should return LATEST' do
+          expect(iterator_args).to include({ shard_iterator_type: 'LATEST' })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds heartbeat checks for the consumer. If the consumer's last heartbeat is older than the given `retention_period_hours` (typically 24 hours on a "free" tier), consume from the latest.

Fixes: https://saleswhale.atlassian.net/browse/TUNA-64