### PR TITLE
feat: Periodically clear away dead ShardReaders

### DIFF
--- a/lib/kinesis/consumer.rb
+++ b/lib/kinesis/consumer.rb
@@ -65,6 +65,10 @@ module Kinesis
 
     # 1 thread per shard, will indefinitely push to queue
     def setup_shards
+      @shards.each do |shard_id, shard|
+        shutdown_shard_reader(shard_id) unless shard.alive?
+      end
+
       response = @kinesis_client.list_shards(
         stream_name: @stream_name,
         shard_filter: { type: 'AT_LATEST' }

--- a/lib/kinesis/shard_reader.rb
+++ b/lib/kinesis/shard_reader.rb
@@ -74,7 +74,7 @@ module Kinesis
             shard_iterator: @shard_iterator
           }
         )
-        raise e
+        sleep_time = false
       end
 
       sleep_time

--- a/lib/kinesis/shard_reader.rb
+++ b/lib/kinesis/shard_reader.rb
@@ -43,6 +43,7 @@ module Kinesis
             shard_id: @shard_id
           }
         )
+        # TODO: is it possible there are records in resp here?
         return false
       end
 

--- a/lib/kinesis/shard_reader.rb
+++ b/lib/kinesis/shard_reader.rb
@@ -74,8 +74,7 @@ module Kinesis
             shard_iterator: @shard_iterator
           }
         )
-
-        sleep_time = false
+        raise e
       end
 
       sleep_time

--- a/lib/kinesis/subthread_loop.rb
+++ b/lib/kinesis/subthread_loop.rb
@@ -4,6 +4,7 @@ module Kinesis
   # Kinesis::Subthread
   class Subthread
     attr_reader :thread
+    delegate :alive?, to: :thread
 
     def initialize(_)
       @thread = nil

--- a/lib/kinesis/subthread_loop.rb
+++ b/lib/kinesis/subthread_loop.rb
@@ -4,7 +4,6 @@ module Kinesis
   # Kinesis::Subthread
   class Subthread
     attr_reader :thread
-    delegate :alive?, to: :thread
 
     def initialize(_)
       @thread = nil
@@ -18,6 +17,10 @@ module Kinesis
 
     def run
       raise NotImplementedError
+    end
+
+    def alive?
+      @thread.alive?
     end
   end
 

--- a/lib/kinesis/subthread_loop.rb
+++ b/lib/kinesis/subthread_loop.rb
@@ -12,6 +12,7 @@ module Kinesis
 
     def start
       @thread = Thread.new { run }
+      @thread.abort_on_exception = true
     end
 
     def run

--- a/lib/kinesis/subthread_loop.rb
+++ b/lib/kinesis/subthread_loop.rb
@@ -13,7 +13,7 @@ module Kinesis
 
     def start
       @thread = Thread.new { run }
-      @thread.abort_on_exception = true
+      @thread.report_on_exception = true
     end
 
     def run


### PR DESCRIPTION
#### Changes

- Check for and remove dead threads on every loop of `Kinesis::Consumer@lock_duration`
- Add `report_on_exception` to the reader thread so something is logged if it dies unexpectedly

#### Considerations

`report_on_exception` simply logs to stderr if the thread dies.  An alternative might be `abort_on_exception` which will reraise the exception in the main thread.  I decided to go with the less disruptive option, because there is the alternative case where no exception is raised but the thread stops naturally, and the solution of clearing dead ShardReaders in the loop in Consumer covers both cases.