### PR TITLE
Reduce the amount of logs generated by Aws::Kinesis::Errors::ServiceError

### DIFF
--- a/lib/kinesis/shard_reader.rb
+++ b/lib/kinesis/shard_reader.rb
@@ -61,7 +61,7 @@ module Kinesis
         @logger.info(
           {
             message: 'Retryable exception encountered when getting records',
-            error: e,
+            error: { code: e.code },
             retry_count: @retries
           }
         )
@@ -69,7 +69,7 @@ module Kinesis
         @logger.info(
           {
             message: 'Error encountered when getting records',
-            error: e,
+            error: { code: e.code },
             shard_iterator: @shard_iterator
           }
         )


### PR DESCRIPTION
Cherry pick the reasonably-sized piece from AWS' error objects for logging.  The other key in this object, `context`, appears to be something like 70KB big in some cases.