### PR TITLE
feat: Use a SizedQueue for records [TUNA-83]

### DIFF
--- a/lib/kinesis/consumer.rb
+++ b/lib/kinesis/consumer.rb
@@ -10,6 +10,7 @@ module Kinesis
   class Consumer
     LOCK_DURATION = 30 # seconds
     READ_INTERVAL = 0.05 # seconds
+    MAX_RECORDS = 1000
 
     def initialize(
       stream_name:,
@@ -24,7 +25,7 @@ module Kinesis
       @lock_duration = lock_duration
       @kinesis_client = kinesis[:client] || Aws::Kinesis::Client.new
       @reader_sleep_time = reader_sleep_time
-      @record_queue = Queue.new
+      @record_queue = SizedQueue.new(MAX_RECORDS)
       @shards = Concurrent::Hash.new
       @stream_name = stream_name
       @logger = logger || Logger.new($stdout)


### PR DESCRIPTION
Attempt to improve the memory situation by limiting the size of records using a [SizedQueue](https://ruby-doc.org/core-2.5.1/SizedQueue.html). It blocks on `push` if the queue is full, so should apply some backpressure on ShardReaders.

Not sure what a good number for this is.