### PR TITLE
feat: Exclude data from the log output TUNA-83

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     kinesis (1.0.2)
+      activesupport
       aws-sdk-dynamodb (~> 1)
       aws-sdk-kinesis (~> 1)
       concurrent-ruby (~> 1.0)
@@ -9,6 +10,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ast (2.4.1)
     aws-eventstream (1.1.1)
     aws-partitions (1.465.0)
@@ -27,7 +34,10 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
+    minitest (5.14.4)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -62,7 +72,10 @@ GEM
     rubocop-ast (1.4.0)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.11.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/kinesis.gemspec
+++ b/kinesis.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rubocop'
 
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'aws-sdk-dynamodb', '~> 1'
   spec.add_dependency 'aws-sdk-kinesis', '~> 1'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'

--- a/lib/kinesis/consumer.rb
+++ b/lib/kinesis/consumer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/except'
 require 'concurrent/hash'
 require 'kinesis/shard_reader'
 require 'kinesis/state'
@@ -102,7 +103,10 @@ module Kinesis
 
       shard_id, item = @record_queue.pop
 
-      @logger.info({ message: 'Got record', item: item })
+      @logger.info({
+        message: 'Got record',
+        item: item.except(:data)
+      })
 
       yield item
 


### PR DESCRIPTION
Clutching at straws, I thought maybe this could be a cause memory usage spikes in the log router for the task.

Also, consumers of this library might not want the _contents_ of their events sent to the logger.  Anyone that does want it can log the data themselves in their callback, as we do with Engage in `HandleEventWorker`.

#### Considerations

I added activesupport just for the `Hash#except` method.  I assumed almost everyone that might want to use this library would probably have activesupport already, but maybe I could inline the `except` definition instead.