### PR TITLE
fix: if shard is not locked, skip until next run

### DIFF
--- a/lib/kinesis/consumer.rb
+++ b/lib/kinesis/consumer.rb
@@ -96,10 +96,12 @@ module Kinesis
 
       shard_id, item = @record_queue.pop
 
-      @logger.info({
-        message: 'Got record',
-        item: item.except(:data)
-      })
+      @logger.info(
+        {
+          message: 'Got record',
+          item: item.except(:data)
+        }
+      )
 
       yield item
 


### PR DESCRIPTION
If shard is not locked, just shutdown the shard reader, then continue to the next shard in the list